### PR TITLE
Decide early if a view is lintable

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -36,14 +36,15 @@ class SublimeSyntax(Linter):
     in order to provide the full functionality.
     """
 
-    # Must be active on all syntaxes,
-    # so we can check view's eligibility in the `run` method.
-    syntax = '*'
     cmd = None
     regex = (
         r'^[^:]+:(?P<line>\d+):((?P<col>\d+):)? '
         r'(?P<message>.+)'
     )
+    # An empty selector matches all views
+    defaults = {
+        'selector': ''
+    }
     word_re = r'.'  # only highlight a single character
 
     @classmethod

--- a/linter.py
+++ b/linter.py
@@ -64,8 +64,7 @@ class SublimeSyntax(Linter):
 
         # But, essentially all files can be syntax tests, if they contain
         # a magic first line
-        code = view.substr(sublime.Region(0, view.size()))
-        first_line = code[:code.find("\n")]
+        first_line = view.substr(view.line(0))
         match = re.match(r'^(\S*) SYNTAX TEST "([^"]*)"', first_line)
         if match:
             return True

--- a/linter.py
+++ b/linter.py
@@ -56,17 +56,21 @@ class SublimeSyntax(Linter):
 
         filename = view.file_name() or ''
         basename = os.path.basename(filename)
-        if not basename or not basename.startswith("syntax_test"):
-            # This actually gets reported by the test runner,
-            # so we only check for an additionally qualifying file
-            # if the filename check fails.
-            code = view.substr(sublime.Region(0, view.size()))
-            first_line = code[:code.find("\n")]
-            match = re.match(r'^(\S*) SYNTAX TEST "([^"]*)"', first_line)
-            if not match:
-                return False
 
-        return True
+
+        # Fast path
+        if basename and basename.startswith("syntax_test"):
+            return True
+
+        # But, essentially all files can be syntax tests, if they contain
+        # a magic first line
+        code = view.substr(sublime.Region(0, view.size()))
+        first_line = code[:code.find("\n")]
+        match = re.match(r'^(\S*) SYNTAX TEST "([^"]*)"', first_line)
+        if match:
+            return True
+
+        return False
 
     def run(self, cmd, code):
         """Perform linting."""

--- a/linter.py
+++ b/linter.py
@@ -49,6 +49,11 @@ class SublimeSyntax(Linter):
     @classmethod
     def can_lint_view(cls, view, settings):
         """Check if file is 'lintable'."""
+        # Check `super` first bc it has the cheap, fast checks, e.g.
+        # if this linter has been disabled.
+        if not super().can_lint_view(view, settings):
+            return False
+
         filename = view.file_name() or ''
         basename = os.path.basename(filename)
         if not basename or not basename.startswith("syntax_test"):
@@ -61,7 +66,7 @@ class SublimeSyntax(Linter):
             if not match:
                 return False
 
-        return super().can_lint_view(view, settings)
+        return True
 
     def run(self, cmd, code):
         """Perform linting."""


### PR DESCRIPTION
Hi @FichteFoll!

In SL4, we have `can_lint_view` which decides if a linter should be assigned
to a view. This is important because otherwise, all views effectively get
elected, and the status bar will always include `sublimesyntax(ok)`.